### PR TITLE
Add `npm install` to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 To start your Phoenix app:
 
-  1. Install dependencies with `mix deps.get`
+  1. Install dependencies with `mix deps.get && npm install`
   2. Create and migrate your database with `mix ecto.create && mix ecto.migrate`
   3. Start Phoenix endpoint with `mix phoenix.server`
 


### PR DESCRIPTION
Otherwise you get the following warning:

```
[error] Could not start node watcher because script "node_modules/brunch/bin/brunch" does not exist. Your Phoenix application is still running, however assets won't be compiled. You may fix this by running "npm install".
```